### PR TITLE
Update for current Pester

### DIFF
--- a/Module/plasterManifest.xml
+++ b/Module/plasterManifest.xml
@@ -68,8 +68,8 @@
     <!-- Appveyor -->
     <templateFile condition="($PLASTER_PARAM_Options -contains 'Appveyor')" source='source/appveyor.yml' destination='${PLASTER_PARAM_ModuleName}/appveyor.yml' />
     <!-- Required modules -->
-    <requireModule name="Pester" condition="$PLASTER_PARAM_Options -contains 'Pester'" minimumVersion="3.4.0" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file.`nWithout version 3.4.0, VS Code will not display Pester warnings and errors in the Problems panel."/>
-    <requireModule name="InvokeBuild" condition="$PLASTER_PARAM_Options -contains 'InvokeBuild'" minimumVersion="3.6.5" message="Without InvokeBuild, you will not be able to build the module and create a production version."/>
+    <requireModule name="Pester" condition="$PLASTER_PARAM_Options -contains 'Pester'" minimumVersion="5.3.0" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file."/>
+    <requireModule name="InvokeBuild" condition="$PLASTER_PARAM_Options -contains 'InvokeBuild'" minimumVersion="3.2.1" message="Without InvokeBuild, you will not be able to build the module and create a production version."/>
     <requireModule name="ModuleBuilder" condition="$PLASTER_PARAM_Options -contains 'InvokeBuild'" minimumVersion="1.0.0" message="Without ModuleBuilder, you will not be able to build the module and create a production version."/>
     <!-- Summary messages -->
     <message>&#10;&#10;Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.&#10;&#10;</message>

--- a/Module/source/Readme.md
+++ b/Module/source/Readme.md
@@ -16,7 +16,7 @@ To speed up module load time and minimize the amount of files that needs to be s
 
 To build the module, make sure you have the following pre-req modules:
 
-- Pester (Required Version 4.1.1)
+- Pester (Required Version 5.3.0)
 - InvokeBuild (Required Version 3.2.1)
 - PowerShellGet (Required Version 1.6.0)
 - ModuleBuilder (Required Version 1.0.0)

--- a/Module/source/invoke.build.ps1
+++ b/Module/source/invoke.build.ps1
@@ -1,6 +1,6 @@
 #Requires -Modules @{ModuleName='InvokeBuild';ModuleVersion='3.2.1'}
 #Requires -Modules @{ModuleName='PowerShellGet';ModuleVersion='1.6.0'}
-#Requires -Modules @{ModuleName='Pester';ModuleVersion='4.1.1'}
+#Requires -Modules @{ModuleName='Pester';ModuleVersion='5.3.0'}
 #Requires -Modules @{ModuleName='ModuleBuilder';ModuleVersion='1.0.0'}
 
 $Script:IsAppveyor = $null -ne $env:APPVEYOR
@@ -13,7 +13,7 @@ task Clean {
 
 task TestCode {
     Write-Build Yellow "`n`n`nTesting dev code before build"
-    $TestResult = Invoke-Pester -Script "$PSScriptRoot\Test\Unit" -Tag Unit -Show 'Header','Summary' -PassThru
+    $TestResult = Invoke-Pester -Path "$PSScriptRoot\Test\Unit" -Tag Unit -PassThru
     if($TestResult.FailedCount -gt 0) {throw 'Tests failed'}
 }
 
@@ -42,9 +42,19 @@ task MakeHelp -if (Test-Path -Path "$PSScriptRoot\Docs") {
 
 task TestBuild {
     Write-Build Yellow "`n`n`nTesting compiled module"
-    $Script =  @{Path="$PSScriptRoot\test\Unit"; Parameters=@{ModulePath=$Script:CompileResult.ModuleBase}}
-    $CodeCoverage = (Get-ChildItem -Path $Script:CompileResult.ModuleBase -Filter *.psm1).FullName
-    $TestResult = Invoke-Pester -Script $Script -CodeCoverage $CodeCoverage -Show None -PassThru
+
+    $container = New-PesterContainer -Path "$PSScriptRoot\test\Unit" -Data @{ModulePath=$Script:CompileResult.ModuleBase}
+
+    $config = New-PesterConfiguration
+    $config.CodeCoverage.Enabled = $true
+    $config.CodeCoverage.Path = (Get-ChildItem -Path $Script:CompileResult.ModuleBase -Filter *.psm1).FullName
+    $config.Output.Verbosity = "None"
+    $config.Run.Container = $container
+    $config.Run.PassThru = $true
+
+    $TestResult = Invoke-Pester -Configuration $config
+    $TestResult.CodeCoverage|Add-Member -MemberType NoteProperty -Name MissedCommands -Value $TestResult.CodeCoverage.CommandsMissed
+    Remove-Item $PSScriptRoot\coverage.xml -ErrorAction SilentlyContinue
 
     if($TestResult.FailedCount -gt 0) {
         Write-Warning -Message "Failing Tests:"
@@ -55,10 +65,19 @@ task TestBuild {
         throw 'Tests failed'
     }
 
-    $CodeCoverageResult = $TestResult | Convert-CodeCoverage -SourceRoot "$PSScriptRoot\Source" -Relative
-    $CodeCoveragePercent = $TestResult.CodeCoverage.NumberOfCommandsExecuted/$TestResult.CodeCoverage.NumberOfCommandsAnalyzed*100 -as [int]
+    $CodeCoverageResult = $TestResult | Convert-CodeCoverage -SourceRoot "$PSScriptRoot\Source"
+    $CodeCoveragePercent = $TestResult.CodeCoverage.CommandsExecutedCount/$TestResult.CodeCoverage.CommandsAnalyzedCount*100 -as [int]
     Write-Verbose -Message "CodeCoverage is $CodeCoveragePercent%" -Verbose
-    $CodeCoverageResult | Group-Object -Property SourceFile | Sort-Object -Property Count | Select-Object -Property Count, Name -Last 10
+    $MissedCommands = $CodeCoverageResult | Group-Object -Property SourceFile | Sort-Object -Property Count -Descending | Select-Object -Property Count, Name -First 10
+
+    if($MissedCommands.length -gt 0) {
+        Write-Verbose -Message "Commands Missed | Source File" -Verbose
+        Write-Verbose -Message "----------------|------------" -Verbose
+        $MissedCommands | ForEach-Object {
+            $Line = "{0,15} | {1}" -f $_.Count, $_.Name
+            Write-Verbose $Line -Verbose
+        }
+    }
 }
 
 task . Clean, TestCode, Build

--- a/Module/source/invoke.build.ps1
+++ b/Module/source/invoke.build.ps1
@@ -68,7 +68,8 @@ task TestBuild {
     $CodeCoverageResult = $TestResult | Convert-CodeCoverage -SourceRoot "$PSScriptRoot\Source"
     $CodeCoveragePercent = $TestResult.CodeCoverage.CommandsExecutedCount/$TestResult.CodeCoverage.CommandsAnalyzedCount*100 -as [int]
     Write-Verbose -Message "CodeCoverage is $CodeCoveragePercent%" -Verbose
-    $MissedCommands = $CodeCoverageResult | Group-Object -Property SourceFile | Sort-Object -Property Count -Descending | Select-Object -Property Count, Name -First 10
+    $MissedCommands = @()
+    $MissedCommands += $CodeCoverageResult | Group-Object -Property SourceFile | Sort-Object -Property Count -Descending | Select-Object -Property Count, Name -First 10
 
     if($MissedCommands.length -gt 0) {
         Write-Verbose -Message "Commands Missed | Source File" -Verbose

--- a/Module/source/test/Module.T.ps1
+++ b/Module/source/test/Module.T.ps1
@@ -1,17 +1,20 @@
 param(
     $ModulePath = "$PSScriptRoot\..\..\Source\"
 )
-# Remove trailing slash or backslash
-$ModulePath = $ModulePath -replace '[\\/]*$'
-$ModuleName = (Get-Item "$ModulePath\..").Name
-$ModuleManifestName = '<%=$PLASTER_PARAM_ModuleName%>.psd1'
-$ModuleManifestPath = Join-Path -Path $ModulePath -ChildPath $ModuleManifestName
+
+BeforeAll {
+    # Remove trailing slash or backslash
+    $ModulePath = $ModulePath -replace '[\\/]*$'
+    $ModuleName = (Get-Item "$ModulePath\..").Name
+    $ModuleManifestName = '<%=$PLASTER_PARAM_ModuleName%>.psd1'
+    $ModuleManifestPath = Join-Path -Path $ModulePath -ChildPath $ModuleManifestName
+}
 
 Describe 'Core Module Tests' -Tags 'CoreModule', 'Unit' {
 
     It 'Passes Test-ModuleManifest' {
         Test-ModuleManifest -Path $ModuleManifestPath
-        $? | Should Be $true
+        $? | Should -Be $true
     }
 
     It 'Loads from module path without errors' {


### PR DESCRIPTION
The existing code generated errors using versions of Pester older than 5.3.0. These changes allow Pester versions 5.3.0 - 5.5.0 (current) to complete successfully.

Fixes #3